### PR TITLE
Include the flag saving/restoring macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,34 +105,35 @@ if test x"$use_xalan" != x"no" ; then
 
   if test $XALANCROOT; then
 
-    AC_MSG_CHECKING([for Xalan headers in XALANCROOT])
+    AC_MSG_NOTICE([looking for Xalan headers in $XALANCROOT])
 
-    OLD_CPPFLAGS=$CPPFLAGS
     # Updated to include nls/include as this is generally needed for
     # compilation against non-installed xalan.
     # Also now include XALANCROOT/include to cater for installed xalan
-    CPPFLAGS=["-I${XALANCROOT}/src -I${XALANCROOT}/include -I${XALANCROOT}/nls/include ${CPPFLAGS}"]
-
-    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <xalanc/Include/XalanVersion.hpp>]])],[xalan_found=yes 
-      LIBS="-L${XALANCROOT}/lib -lxalan-c ${LIBS}"
-      AC_MSG_RESULT([found])],[CPPFLAGS=$OLD_CPPFLAGS
-      AC_MSG_RESULT([no])]);
+    xalan_CFLAGS="-I${XALANCROOT}/src -I${XALANCROOT}/include -I${XALANCROOT}/nls/include"
+    xalan_LIBS="-L${XALANCROOT}/lib -lxalan-c"
+    AX_SAVE_FLAGS_WITH_PREFIX([xalan],[[CFLAGS]])
+    AC_CHECK_HEADER([xalanc/Include/XalanVersion.hpp],
+                    [xalan_found=yes])
+    AX_RESTORE_FLAGS_WITH_PREFIX([xalan],[[CFLAGS]])
 
   fi
 
   if test -z "$xalan_found" ; then
 
-    AC_MSG_CHECKING([for Xalan in system includes])
-    AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <xalanc/Include/XalanVersion.hpp>]])],
-        [xalan_found=yes 
-        LIBS="${LIBS} -lxalan-c"
-        AC_MSG_RESULT([found])],
-      [AC_MSG_RESULT([no - WARNING - configuring without Xalan])]);
+    AC_MSG_NOTICE([looking for Xalan in system includes])
+    unset ac_cv_header_xalanc_Include_XalanVersion_hpp
+    AC_CHECK_HEADER([xalanc/Include/XalanVersion.hpp],
+                    [xalan_found=yes
+		     xalan_CFLAGS=""
+		     xalan_LIBS="-lxalan-c"],
+		    [AC_MSG_NOTICE([WARNING - configuring without Xalan])])
 
   fi
 fi
 
 if test "${xalan_found}" = "yes" ; then
+AX_SAVE_FLAGS_WITH_PREFIX([xalan],[[CFLAGS],[LIBS]])
 
 AC_MSG_CHECKING([Xalan version])
 AC_PREPROC_IFELSE(
@@ -146,16 +147,13 @@ int i = 0;
     [AC_MSG_FAILURE([Xalan-C 1.11+ is required])])
 
   # Do we need xalanMsg.so?
-  AC_MSG_CHECKING([if libxalanMsg is required])
-  old_libs=$LIBS
-  LIBS="${LIBS} -lxalanMsg"
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[
-    int test=1;
-  ]])],[AC_MSG_RESULT(yes)],[AC_MSG_RESULT(no)
-  LIBS=${old_libs}]);
+  AC_SEARCH_LIBS([XalanInitialize],[xalanMsg],[xalan_LIBS="$LIBS"])
   
   AC_DEFINE([XSEC_HAVE_XALAN],[1],[Define to 1 if Xalan is available.])
+  AC_SUBST([xalan_CFLAGS])
+  AC_SUBST([xalan_LIBS])
 
+AX_RESTORE_FLAGS_WITH_PREFIX([xalan],[[CFLAGS],[LIBS]])
 else
   AC_MSG_NOTICE([Xalan not included in build - XPath and XSLT will not be available])
 fi

--- a/m4/ax_restore_flags_with_prefix.m4
+++ b/m4/ax_restore_flags_with_prefix.m4
@@ -1,0 +1,66 @@
+# =================================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_restore_flags_with_prefix.html
+# =================================================================================
+#
+# SYNOPSIS
+#
+#   AX_RESTORE_FLAGS_WITH_PREFIX(PREFIX, LIST-OF-FLAGS)
+#
+# DESCRIPTION
+#
+#   Restore the flags saved by AX_SAVE_FLAGS_WITH_PREFIX.
+#
+#   Expansion example: AX_RESTORE_FLAGS_WITH_PREFIX([GL], [[CFLAGS],[LIBS]])
+#   expands to
+#
+#     CFLAGS="$gl_saved_flag_cflags"
+#     LIBS="$gl_saved_flag_libs"
+#
+#   One common use case is to define a package specific wrapper macro around
+#   this one, and also restore other variables if needed. For example:
+#
+#     AC_DEFUN([_AX_CHECK_GL_RESTORE_FLAGS], [
+#       AX_RESTORE_FLAGS_WITH_PREFIX([GL],[$1])
+#       AC_LANG_POP([C])
+#     ])
+#
+#     # Restores CFLAGS, LIBS and language state
+#     _AX_CHECK_GL_RESTORE_FLAGS([[CFLAGS],[LIBS]])
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Felix Chern <idryman@gmail.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_RESTORE_FLAGS_WITH_PREFIX],[
+m4_ifval([$2], [
+m4_car($2)="$_ax_[]m4_tolower($1)_saved_flag_[]m4_tolower(m4_car($2))"
+$0($1, m4_cdr($2))])
+])

--- a/m4/ax_save_flags_with_prefix.m4
+++ b/m4/ax_save_flags_with_prefix.m4
@@ -1,0 +1,72 @@
+# ==============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_save_flags_with_prefix.html
+# ==============================================================================
+#
+# SYNOPSIS
+#
+#   AX_SAVE_FLAGS_WITH_PREFIX(PREFIX, LIST-OF-FLAGS)
+#
+# DESCRIPTION
+#
+#   For each flag in LIST-OF-FLAGS, it expands to lower-cased shell variable
+#   with the prefix holding the flag original value.  The saved variables
+#   can be restored by AX_RESTORE_FLAGS_WITH_PREFIX
+#
+#   As an example: AX_SAVE_FLAGS_WITH_PREFIX([GL], [[CFLAGS],[LIBS]])
+#   expands to
+#
+#     gl_saved_flag_cflags="$CFLAGS"
+#     gl_saved_flag_libs="$LIBS"
+#     CFLAGS="$GL_CFLAGS $CFLAGS"
+#     LIBS="$GL_LIBS $LIBS"
+#
+#   One common use case is to define a package specific wrapper macro around
+#   this one, and also setup other variables if needed. For example:
+#
+#     AC_DEFUN([_AX_CHECK_GL_SAVE_FLAGS], [
+#       AX_SAVE_FLAGS_WITH_PREFIX([GL],[$1])
+#       AC_LANG_PUSH([C])
+#     ])
+#
+#     # pushes GL_CFLAGS and GL_LIBS to CFLAGS and LIBS
+#     # also set the current language to test to C
+#     _AX_CHECK_GL_SAVE_FLAGS([[CFLAGS],[LIBS]])
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Felix Chern <idryman@gmail.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_SAVE_FLAGS_WITH_PREFIX],[
+m4_ifval([$2], [
+_ax_[]m4_tolower($1)_saved_flag_[]m4_tolower(m4_car($2))="$m4_car($2)"
+m4_car($2)="$$1_[]m4_car($2) $m4_car($2)"
+$0($1, m4_cdr($2))
+])])

--- a/xml-security-c.pc.in
+++ b/xml-security-c.pc.in
@@ -7,6 +7,7 @@ Name: @PACKAGE_NAME@
 Description: Apache XML security C++ library
 Version: @VERSION@
 Libs: -L${libdir} -lxml-security-c
-Cflags: -I${includedir}
+Libs.private: @xalan_LIBS@
+Cflags: -I${includedir} @xalan_CFLAGS@
 Requires: @AX_PACKAGE_REQUIRES@
 Requires.private: @AX_PACKAGE_REQUIRES_PRIVATE@

--- a/xsec/Makefile.am
+++ b/xsec/Makefile.am
@@ -21,8 +21,8 @@ AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir)
 noinst_PROGRAMS = ${samples}
 bin_PROGRAMS = ${tools}
 
-AM_CXXFLAGS = $(xerces_CFLAGS)
-LDADD = libxml-security-c.la $(xerces_LIBS)
+AM_CXXFLAGS = $(xerces_CFLAGS) $(xalan_CFLAGS)
+LDADD = libxml-security-c.la $(xerces_LIBS) $(xalan_LIBS)
 
 #
 # The following are sample programs.  They are NOT installed
@@ -94,7 +94,7 @@ tools += xsec-c14n
 xsec_c14n_SOURCES = \
    tools/c14n/c14n.cpp
 xsec_c14n_CPPFLAGS = $(AM_CPPFLAGS) -DXSEC_BUILDING_TOOLS
- 
+
 tools += xsec-checksig
 xsec_checksig_SOURCES = \
    tools/checksig/checksig.cpp \
@@ -157,11 +157,13 @@ endif
 libxml_security_c_la_CPPFLAGS = $(AM_CPPFLAGS) -DXSEC_BUILDING_LIBRARY
 
 libxml_security_c_la_CXXFLAGS = \
+   $(xalan_CFLAGS) \
    $(xerces_CFLAGS) \
    $(openssl_CFLAGS) \
    $(nss_CFLAGS)
 
 libxml_security_c_la_LIBADD = \
+   $(xalan_LIBS) \
    $(xerces_LIBS) \
    $(openssl_LIBS) \
    $(nss_LIBS)


### PR DESCRIPTION
And bring Xalan detection on par with the other libraries. I'm not sure of the point of the xalanMsg test (static linking?), so it's somewhat rudimentary, but should work as before.