### PR TITLE
Include missing headers

### DIFF
--- a/xsec/Makefile.am
+++ b/xsec/Makefile.am
@@ -316,6 +316,8 @@ utilsinclude_HEADERS = \
   utils/XSECXPathNodeList.hpp \
   utils/XSECSafeBufferFormatter.hpp \
   utils/XSECBinTXFMInputStream.hpp \
+  utils/XSECAlgorithmSupport.hpp \
+  utils/XSECDOMUtils.hpp \
   utils/XSECPlatformUtils.hpp 
 
 xencinclude_HEADERS = \


### PR DESCRIPTION
Fixes [1] when we are migrating from 1.7.x to 2.0.x 

[1] 

    BUILDSTDERR: XadesSignature.cpp:66:10: fatal error: xsec/utils/XSECDOMUtils.hpp: No such file or directory
    BUILDSTDERR:  #include <xsec/utils/XSECDOMUtils.hpp>