### PR TITLE
OpenSSLCryptoHash.cpp: Allow use of md5 in fips mode

### DIFF
--- a/xsec/enc/OpenSSL/OpenSSLCryptoHash.hpp
+++ b/xsec/enc/OpenSSL/OpenSSLCryptoHash.hpp
@@ -40,6 +40,10 @@
 
 #   include <openssl/evp.h>
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+#   include <openssl/core_names.h>
+#endif
+
 /**
  * @ingroup opensslcrypto
  */
@@ -156,7 +160,9 @@ private:
     unsigned char       m_mdValue[EVP_MAX_MD_SIZE];     // Final output
     unsigned int        m_mdLen;                        // Length of digest
     HashType            m_hashType;                     // What type of hash is this?
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+    OSSL_LIB_CTX 	*octx;
+#endif
 };
 
 #endif /* XSEC_HAVE_OPENSSL */


### PR DESCRIPTION
Do this properly by comparing version of openssl in the system

openssl-3.x has removed EVP_MD_CTX_FLAG_NON_FIPS_ALLOW support
And we need to use EVP_MD_fetch(...) API to use md5 while in fips mode

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>